### PR TITLE
Added a findOverlap method for character vectors.

### DIFF
--- a/inst/unitTests/test_findOverlaps-methods.R
+++ b/inst/unitTests/test_findOverlaps-methods.R
@@ -332,3 +332,41 @@ test_poverlaps <- function() {
                      GRanges("chr1:16-20"))
     checkIdentical(ans, Rle(c(FALSE, TRUE)))
 }
+
+test_findOverlaps_character <- function() {
+    gr <- GRanges(c("chr1:11-15", "chr1:5-100", "chr2:10-11"))
+
+    ans <- findOverlaps(gr, "chr1")
+    checkIdentical(queryHits(ans), which(seqnames(gr)=="chr1"))
+
+    ans <- findOverlaps(gr, c("chr2", "chr1"))
+    checkIdentical(as.character(seqnames(gr)[queryHits(ans)]), c("chr2", "chr1")[subjectHits(ans)])
+
+    # Works in the other direction.
+    ans <- findOverlaps("chr2", gr)
+    checkIdentical(subjectHits(ans), which(seqnames(gr)=="chr2"))
+
+    # Works for GRLs.
+    gr <- GRanges(c("chr1:11-15", "chr1:5-100", "chr2:1-10", "chr2:10-11"))
+    grl <- split(gr, c(1,2,2,3))
+    ans <- findOverlaps(grl, "chr2")
+    checkIdentical(queryHits(ans), unname(which(any(seqnames(grl) %in% "chr2"))))
+
+    ans <- findOverlaps(grl, c("chr2", "chr1"))
+    checkIdentical(queryHits(ans)[subjectHits(ans)==1L], unname(which(any(seqnames(grl) %in% "chr2"))))
+    checkIdentical(queryHits(ans)[subjectHits(ans)==2L], unname(which(any(seqnames(grl) %in% "chr1"))))
+
+    ans <- findOverlaps(grl, c("chr2", "chr1"), type="within")
+    checkIdentical(queryHits(ans)[subjectHits(ans)==1L], unname(which(all(seqnames(grl) %in% "chr2"))))
+    checkIdentical(queryHits(ans)[subjectHits(ans)==2L], unname(which(all(seqnames(grl) %in% "chr1"))))
+
+    # Same result in the other direction.
+    ans2 <- findOverlaps(c("chr2", "chr1"), grl)
+    checkIdentical(subjectHits(ans2)[queryHits(ans2)==1L], unname(which(any(seqnames(grl) %in% "chr2"))))
+    checkIdentical(subjectHits(ans2)[queryHits(ans2)==2L], unname(which(any(seqnames(grl) %in% "chr1"))))
+
+    ans2 <- findOverlaps(c("chr2", "chr1"), grl, type="within")
+    checkIdentical(subjectHits(ans2)[queryHits(ans2)==1L], unname(which(all(seqnames(grl) %in% "chr2"))))
+    checkIdentical(subjectHits(ans2)[queryHits(ans2)==2L], unname(which(all(seqnames(grl) %in% "chr1"))))
+}
+

--- a/man/findOverlaps-methods.Rd
+++ b/man/findOverlaps-methods.Rd
@@ -54,6 +54,7 @@
 \arguments{
   \item{query, subject}{
     A \link{GRanges} or \link{GRangesList} object.
+    Either argument may also be a character vector of sequance names.
   }
   \item{maxgap, minoverlap, type}{
     See \code{?\link[IRanges]{findOverlaps}} in the \pkg{IRanges} package
@@ -97,6 +98,16 @@
   For \code{type="equal"} with GRangesList objects, \code{query[[i]]}
   matches \code{subject[[j]]} iff for each range in \code{query[[i]]}
   there is an identical range in \code{subject[[j]]}, and vice versa.
+
+  When either the query or subject is a character vector, the values are
+  interpreted as the sequence names. A range is considered to \dQuote{overlap}
+  with a sequence name if it lies on that sequence. \code{maxgap} and
+  \code{minoverlap} are ignored. \code{type} is ignored for \link{GRanges}, and
+  only \code{type="any"} and \code{type="within"} are used for
+  \link{GRangesList} inputs (the latter requiring all ranges to lie on the
+  specified sequence to be considered as an overlap). This method allows users
+  to conveniently identify ranges on certain chromosomes without worrying about
+  whether the ranges are stored in a \link{GRanges} or \link{GRangesList}. 
 }
 
 \value{


### PR DESCRIPTION
Closes #52 with the following syntactic sugar:

```r
example(GenomicRanges, echo=FALSE)
findOverlaps(gr, "chr1")
## Hits object with 2 hits and 0 metadata columns:
##       queryHits subjectHits
##       <integer>   <integer>
##   [1]         5           1
##   [2]         6           1
##   -------
##   queryLength: 10 / subjectLength: 1
```

Also works for GRLs:

```r
example(GRangesList, echo=FALSE)
findOverlaps(grl, c("Chrom1"))
## Hits object with 2 hits and 0 metadata columns:
##            from        to
##       <integer> <integer>
##   [1]         2         1
##   [2]         3         1
##   -------
##   nLnode: 3 / nRnode: 1

findOverlaps(grl, c("Chrom1"), type="within")
## Hits object with 1 hit and 0 metadata columns:
##            from        to
##       <integer> <integer>
##   [1]         2         1
##   -------
##   nLnode: 3 / nRnode: 1
```

`maxgap` and `minoverlap` are currently ignored completely. `type` is mostly ignored except for the GRL methods, which require all ranges in a GRL element to lie within the sequence name to consider an overlap with that name.

Note that `overlapsAny` and friends don't yet work out of the box; I'm guessing a `Vector_OR_vector` signature needs to be added to the methods so that it can pass along the character vectors properly.